### PR TITLE
fix: #396 phenotype filter not returns always 0 studies

### DIFF
--- a/src/providers/Filter/mapper/index.ts
+++ b/src/providers/Filter/mapper/index.ts
@@ -52,4 +52,10 @@ export const studyMapping: Map<string, string> = new Map([
     ['vital_status', 'donors.vital_status'],
     ['age_at_recruitment', 'donors.age_at_recruitment'],
     ['internal_donor_id', 'donors.internal_donor_id'],
+    ['observed_phenotype_tagged.main_category', 'donors.observed_phenotype_tagged.main_category'],
+    ['observed_phenotype_tagged.name', 'donors.observed_phenotype_tagged.name'],
+    ['diagnoses.tagged_mondo.name', 'donors.diagnoses.tagged_mondo.name'],
+    ['diagnoses.tagged_mondo.main_category', 'donors.diagnoses.tagged_mondo.main_category'],
+    ['diagnoses.tagged_icd.main_category', 'donors.diagnoses.tagged_icd.main_category'],
+    ['diagnoses.tagged_icd.name', 'donors.diagnoses.tagged_icd.name'],
 ]);


### PR DESCRIPTION
# BUG

closes #396

## Description

HPO, Mondo and ICD-10 filters in study page should not return always 0 studies

## Validation

- [ ] QA Done

## Screenshot (Avant et Après)
![image](https://user-images.githubusercontent.com/29788342/127915242-97291410-1b8a-43a8-8a22-a4f576ed7539.png)

![image](https://user-images.githubusercontent.com/29788342/127915321-cb8b142d-9f9b-48d6-9b2d-5da01b8816ed.png)


## QA

validate all HPO, Mondo and ICD-10 filters in File Repo (donors tab):
![image](https://user-images.githubusercontent.com/29788342/127915639-03ba7316-dc39-4ecd-8b02-ef0632b73d82.png)






## Notification

@ QA
