### PR TITLE
fix: #443 and #436 fix drawer width and proper display of save sets d…

### DIFF
--- a/src/components/functionnal/SaveSets/SelectSets.module.scss
+++ b/src/components/functionnal/SaveSets/SelectSets.module.scss
@@ -4,6 +4,10 @@
     margin: 1rem 0;
 }
 
+.donorSearchContainer {
+    display: grid;
+}
+
 .emptyDataContainer {
     background: $gray-3;
     padding: .8rem 1.6rem;

--- a/src/components/functionnal/SaveSets/SelectSets.tsx
+++ b/src/components/functionnal/SaveSets/SelectSets.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { AiOutlineDown } from 'react-icons/ai';
-import StackLayout from '@ferlab/ui/core/layout/StackLayout';
 import { Select } from 'antd';
 
 import ListItem from 'components/functionnal/SaveSets/ListItem';
 import SelectWithCustomTag from 'components/functionnal/Select';
 
 import styles from './SelectSets.module.scss';
+
 const { OptGroup, Option } = Select;
 
 interface ISelectSets {
@@ -67,7 +67,7 @@ const SelectSets: React.FunctionComponent<ISelectSets> = ({ data, dictionary, on
 
     const currentValues = data.reduce((acc, item) => [...acc, ...(item.selectedValues || [])], [] as string[]);
     return (
-        <StackLayout vertical>
+        <div className={styles.donorSearchContainer}>
             <label>{dictionary?.title || 'Select'}</label>
             <SelectWithCustomTag
                 listHeight={150}
@@ -108,7 +108,7 @@ const SelectSets: React.FunctionComponent<ISelectSets> = ({ data, dictionary, on
                     return options;
                 })}
             </SelectWithCustomTag>
-        </StackLayout>
+        </div>
     );
 };
 

--- a/src/components/layouts/Sidebar/SideBar.scss
+++ b/src/components/layouts/Sidebar/SideBar.scss
@@ -11,8 +11,7 @@
     overflow: hidden;
 
     &:not(&-collapsed) {
-        max-width: 420px;
-        min-width: 320px;
+        width: 400px;
         > :first-child {
             margin-bottom: 1.6rem;
         }    


### PR DESCRIPTION
…ropdown

# [FEATURE] [Fix visual issues with the LHS drawer and save sets display]

closes #[443 and 436]

## Description

Visual issues (see screens)

## Validation

- [ ] Code Approved
- [ ] QA Done

## Screenshot (Avant et Après)

Before:
![image](https://user-images.githubusercontent.com/29788342/129373489-a8311416-1226-45f5-92b7-7211b7d4e514.png)


![image](https://user-images.githubusercontent.com/29788342/129373780-8314a7d8-cd87-4215-8126-c4d4c9bfd1d9.png)

After:
![image](https://user-images.githubusercontent.com/29788342/129374374-07e2c201-4ca1-422f-90a4-3b3aff926484.png)

## Notification

@ QA, @creativeyann17 
